### PR TITLE
Fix buiding containers doesn't complete

### DIFF
--- a/application/photoalbum/Dockerfile
+++ b/application/photoalbum/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get -qq update; \
     apt-get -qq -y install python python-dev python-pip \
         python-flask python-requests python-wtforms python-arrow \
         python-flask-sqlalchemy python-pymysql python-flaskext.wtf
+RUN pip install --upgrade pip
 RUN pip install --upgrade setuptools \
         google-cloud==0.34.0 google-auth-httplib2==0.0.3 \
         google-cloud-storage==1.13.0 google-cloud-pubsub==0.38.0

--- a/application/safeimage/Dockerfile
+++ b/application/safeimage/Dockerfile
@@ -5,6 +5,7 @@ ENV REFRESHED_AT 2018/10/13
 RUN apt-get -qq update; \
     apt-get -qq -y upgrade; \
     apt-get -qq -y install python python-dev python-pip
+RUN pip install --upgrade pip
 RUN pip install --upgrade setuptools pillow \
         google-cloud==0.34.0 google-auth-httplib2==0.0.3 \
         google-cloud-storage==1.13.0 google-cloud-pubsub==0.38.0 \

--- a/application/thumbnail/Dockerfile
+++ b/application/thumbnail/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get -qq update; \
     apt-get -qq -y upgrade; \
     apt-get -qq -y install python python-dev python-pip \
         python-flask python-flask-sqlalchemy python-pymysql
+RUN pip install --upgrade pip
 RUN pip install --upgrade setuptools pillow \
         google-cloud==0.34.0 google-auth-httplib2==0.0.3 \
         google-cloud-storage==1.13.0 google-cloud-pubsub==0.38.0 \


### PR DESCRIPTION
**Issues:**

Building following containers doesn't complete as expected.

- photoalbum
- thumbnail
- safeimage

**Status:**

When running `gcloud builds submit` commands, those stuck with following outputs.

```
・・・
Running setup.py bdist_wheel for grpcio: started
  Running setup.py bdist_wheel for grpcio: still running...
  Running setup.py bdist_wheel for grpcio: still running...
・・・
```

**Root cause:**

It hits [the issue](https://github.com/grpc/grpc/issues/22815) here.

**Solution:**

Run `pip install --upgrade pip` before installing `grpcio` in Dockerfile.


