### PR TITLE
Fix storage paths for images

### DIFF
--- a/application/photoalbum/src/app.py
+++ b/application/photoalbum/src/app.py
@@ -43,7 +43,7 @@ app.config['SQLALCHEMY_DATABASE_URI'] = \
 db = SQLAlchemy(app)
 bucket_name = '{}-photostore'.format(project_id)
 bucket = storage.Client().get_bucket(bucket_name)
-storage_path = 'https://storage.cloud.google.com/{}'.format(bucket_name)
+storage_path = 'https://storage.googleapis.com/{}'.format(bucket_name)
 
 
 content_types = {'jpg': 'image/jpeg', 'jpeg': 'image/jpeg',


### PR DESCRIPTION
**Issues:**

The default image and thumbnails don't show up in the app.

**Root cause:**

The url used in the app(storage.cloud.google.com) requires authentication. Here is the [details](https://cloud.google.com/storage/docs/request-endpoints#access_to_public_objects).

**Solution:**

Update the url to "storage.googleapis.com" that is accessible publicly.