### PR TITLE
Use artifact registry to store container images

### DIFF
--- a/config/photoalbum-deployment.yaml
+++ b/config/photoalbum-deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: photoalbum-app
-        image: gcr.io/[PROJECT_ID]/photoalbum-app@[DIGEST]
+        image: us-central1-docker.pkg.dev/[PROJECT_ID]/photoalbum-repo/photoalbum-app@[DIGEST]
         tty: true
         ports:
         - containerPort: 8080

--- a/config/safeimage-deployment.yaml
+++ b/config/safeimage-deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: safeimage-worker
-        image: gcr.io/[PROJECT_ID]/safeimage-worker@[DIGEST]
+        image: us-central1-docker.pkg.dev/[PROJECT_ID]/photoalbum-repo/safeimage-worker@[DIGEST]
         env:
         - name: PROJECT_ID
           value: "[PROJECT_ID]"

--- a/config/thumbnail-deployment.yaml
+++ b/config/thumbnail-deployment.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
       - name: thumbnail-worker
-        image: gcr.io/[PROJECT_ID]/thumbnail-worker@[DIGEST]
+        image: us-central1-docker.pkg.dev/[PROJECT_ID]/photoalbum-repo/thumbnail-worker@[DIGEST]
         env:
         - name: PROJECT_ID
           value: "[PROJECT_ID]"


### PR DESCRIPTION
As artifact registry is recommended to store container images, I've updated the tutorial and code to use it.